### PR TITLE
Add Secure String Comparison

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const {createHmac} = require('crypto')
+const {createHmac, timingSafeEqual} = require('crypto')
 
 function generate(algorithm, payload, secret) {
 	return `${algorithm}=${createHmac(algorithm, secret).update(payload).digest('hex')}`
@@ -13,7 +13,7 @@ function verify(signature, payload, secret) {
 	}
 	const [algorithm] = parts
 	const verify = generate(algorithm, payload, secret)
-	return verify === signature
+	return timingSafeEqual(Buffer.from(verify), Buffer.from(signature))
 }
 
 exports.verify = verify

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "2.0.0",
   "description": "Generates and verifies signatures",
   "main": "index.js",
+  "engines": {
+    "node": ">=v6.6.0"
+  },
   "files": [
     "LICENSE",
     "README.md"


### PR DESCRIPTION
[`crypto.timingSafeEqual(a, b)`](https://nodejs.org/api/crypto.html#crypto_crypto_timingsafeequal_a_b) from Node.js `crypto` library was added in v6.6.0.

That's why I specified

```json
  "engines": {
    "node": ">=v6.6.0"
  },
```

in the `package.json`.

fix #2 